### PR TITLE
Poprawa UI: dodano placeholder do pola Tagi

### DIFF
--- a/UnoCostAnalyzer/Presentation/SecondPage.xaml
+++ b/UnoCostAnalyzer/Presentation/SecondPage.xaml
@@ -24,8 +24,8 @@
             </utu:NavigationBar.MainCommand>
         </utu:NavigationBar>
         <StackPanel Margin="10,0" Spacing="5" VerticalAlignment="Top" Grid.Row="1">
-            <TextBox Text="{Binding Path=Tags, Mode=TwoWay}" />
             <TextBox PlaceholderText="Kwota" Text="{Binding Path=EditableItem.Cost, Mode=TwoWay}" />
+            <TextBox PlaceholderText="Tagi (opcjonalne)" Text="{Binding Path=Tags, Mode=TwoWay}" />
             <TextBox PlaceholderText="Opis" TextWrapping="Wrap" Text="{Binding Path=EditableItem.Description, Mode=TwoWay}" />
             <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom" Spacing="10" Orientation="Horizontal">
                 <Button Style="{StaticResource FilledTonalButtonStyle}" Command="{Binding OkCommand}" Content="Ok" />


### PR DESCRIPTION
Zmieniono TextBox odpowiadający za tagi, dodając PlaceholderText="Tagi (opcjonalne)" w celu poprawy czytelności i wskazania użytkownikowi przeznaczenia pola. 

