### PR TITLE
Add CreatedAt timestamp to EditableItem in OkCommand

### DIFF
--- a/UnoCostAnalyzer/Presentation/SecondModel.cs
+++ b/UnoCostAnalyzer/Presentation/SecondModel.cs
@@ -16,7 +16,11 @@ public partial record SecondModel
 
     public async Task OkCommand()
     {
-        await _navigator.NavigateBackWithResultAsync(this, data: EditableItem with { Tags = Tags.Split(' ')});
+        await _navigator.NavigateBackWithResultAsync(this, data: EditableItem with
+        {
+            Tags = Tags.Split(' '),
+            CreatedAt = DateTime.Now
+        });
     }
 
     public async Task CancelCommand()


### PR DESCRIPTION
This change updates the `OkCommand` method to also set a `CreatedAt` timestamp (using `DateTime.Now`) when returning a new `EditableItem`.

It allows the system to track when the object was created, in addition to its tags.